### PR TITLE
removed <4.9.0 from transformer versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     rxn-chem-utils>=1.0.3
     scipy>=1.4.1
     torch>=1.5.0,<2.1
-    transformers>=4.0.0,<4.9.0
+    transformers>=4.0.0
 
 [options.package_data]
 rxnmapper =


### PR DESCRIPTION
Updated the `transformers` constraints to remove `<4.9.0`

- Anuv