### PR TITLE
Remove warning about attn_implementation for new transformers versions

### DIFF
--- a/rxnmapper/core.py
+++ b/rxnmapper/core.py
@@ -4,12 +4,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
+from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import numpy as np
 import pkg_resources
 import torch
-from contextlib import contextmanager
 from rxn.chemutils.reaction_equation import ReactionEquation
 from rxn.chemutils.reaction_smiles import (
     ReactionFormat,


### PR DESCRIPTION
This warning started appearing in new `transformers` versions (see #62):

```
AlbertSdpaAttention is used but `torch.nn.functional.scaled_dot_product_attention` does not support non-absolute `position_embedding_type` or `output_attentions=True` or `head_mask`. Falling back to the eager attention implementation, but specifying the eager implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.
```

Setting `attn_implementation="eager"` would break compatibility with versions of transformers older than a year or two. Therefore, we decide to suppress the warning instead.

Fixes #62.