### PR TITLE
fix: set transformer dependency to be between 4.0.0 and 5.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     rxn-chem-utils>=1.0.3
     scipy>=1.4.1
     torch>=1.5.0
-    transformers>=4.0.0
+    transformers>=4.0.0,<5.0.0
 
 [options.package_data]
 rxnmapper =


### PR DESCRIPTION
Set the transformer version to be < 5.0.0 due to there being breaking changes in the newest transformers package.
Due to the dependency for the transformer library requiring > 4.0.0 it will auto try to install the latest version in this case 5.x.x which has breaking changes for the BertTokenizer causing the rxn mapper not to function at all and the tests failing as well. 
<img width="1243" height="236" alt="Screenshot 2026-02-03 at 13 33 59" src="https://github.com/user-attachments/assets/8654b5f8-f076-4bc3-9f5b-4c296e20bd3b" />


With this change everything seems to be working correctly 

 
<img width="1227" height="308" alt="Screenshot 2026-02-03 at 15 25 28" src="https://github.com/user-attachments/assets/943ccd31-21dc-453d-aa68-865a2c9195c5" />
